### PR TITLE
fix: Fix name of the JAR in the release config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -9,7 +9,7 @@
     }],
     ["@semantic-release/github", {
       "assets": [
-        {"path": "target/snippets-*.jar", "label": "tiango-${nextRelease.version}.jar"}
+  {"path": "target/tiango-*.jar", "label": "tiango-${nextRelease.version}.jar"}
       ]
     }],
     ["@semantic-release/git", {


### PR DESCRIPTION
Fix the naming in the release configuration to enable the JAR generation